### PR TITLE
Fix loading event handler

### DIFF
--- a/components/MainContent.tsx
+++ b/components/MainContent.tsx
@@ -20,11 +20,12 @@ export default function MainContent({ children }: MainContentProps) {
   const [contentReady, setContentReady] = useState(false);
 
   // Limit loading state changes to improve performance
-  const handleNavigationStart = useCallback(() => {
+  const handleNavigationStart = useCallback(
     throttle(() => {
       setIsLoading(true);
-    }, 200);
-  }, []);
+    }, 200),
+    []
+  );
 
   useEffect(() => {
     window.addEventListener("beforeunload", handleNavigationStart, {


### PR DESCRIPTION
## Summary
- fix `handleNavigationStart` definition so throttling is stable

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684631078a608321ab0254777576afba