### PR TITLE
Fix potential timeout leak

### DIFF
--- a/components/SpaceBackground.tsx
+++ b/components/SpaceBackground.tsx
@@ -200,7 +200,7 @@ export default function SpaceBackground() {
   }, []);
 
   useEffect(() => {
-    setTimeout(spawnShootingStar, 2000);
+    const timeoutId = setTimeout(spawnShootingStar, 2000);
     const interval = setInterval(() => {
       if (Math.random() > 0.7) {
         const burstCount = Math.floor(randRange(2, 4));
@@ -211,7 +211,10 @@ export default function SpaceBackground() {
         spawnShootingStar();
       }
     }, 7000);
-    return () => clearInterval(interval);
+    return () => {
+      clearTimeout(timeoutId);
+      clearInterval(interval);
+    };
   }, [spawnShootingStar]);
 
   return (


### PR DESCRIPTION
## Summary
- prevent stray shooting star timeout on unmount

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68462fe5f0408321b70415e3964989b3